### PR TITLE
Add state-based APR caps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+lotus
+*.log
+*.json
+loan_count.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# Lotus
+# Lotus CLI Simulator
+
+This project demonstrates how payday lending can vary depending on ethics and regulation. Three selectable modes show distinct philosophies:
+
+- **ethical** – represents an ideal lender guided by bioethical principles (Belmont Report). It begins with a short ethics primer, checks for "meta-consent" to avoid nudging, breaks down every fee in a cost–benefit ledger and ends with philosophical quotes. This mode is intentionally unrealistic: beyond low profit, its generous terms would often require subsidies and may conflict with current payday regulations.
+- **exploitative** – mirrors the worst behaviour found on real payday websites. It personalizes offers by ZIP code, hides data‑sharing consent in tiny text, forces arbitration, adds layered fees, encourages automatic rollovers and even threatens credit reporting. These tactics reflect documented dark patterns and business practices.
+- **regulated** – follows common consumer‑protection rules such as a 36% APR cap, mandatory disclosures and a 24‑hour cancellation window. A quiz confirms the borrower sees the APR, rollovers are banned and a compliance report is printed. This mode illustrates a practical middle ground where lenders remain profitable while obeying law.
+
+The simulator offers features like an amortization schedule and early‑payoff incentive in ethical mode, and a one‑time 0% extension in regulated mode. Sessions can be exported to JSON for research. Each output line references either philosophical ideals or real policy so users understand why the behaviour occurs.
+
+## Build
+Compile with a C++17 compiler. Example:
+
+```bash
+g++ -std=c++17 -I src -o lotus src/*.cpp src/strategies/*.cpp
+```
+
+## Run
+Choose a mode interactively or pass `--mode=` on the command line:
+
+```bash
+./lotus --mode=ethical
+./lotus --mode=exploitative --loan=300
+```
+
+The optional `--loan=` flag pre-fills the desired loan amount so you can skip
+interactive entry.
+
+You can also select a state to demonstrate local usury rules. Example:
+
+```bash
+./lotus --mode=regulated --state=SD --loan=200
+```
+
+Supported states include `SD` (South Dakota, 36% cap with pilot extension), `DE`
+(Delaware), `RI` (Rhode Island, permissive cap) and `UT` (Utah, very high cap).
+
+Session logs are written to the working directory when export is enabled.

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,45 @@
+#ifndef LOTUS_CONFIG_H
+#define LOTUS_CONFIG_H
+
+#include <string>
+
+struct Config {
+    double apr = 24.0;                // Belmont Report ethics
+    double exploitFeeRate = 0.30;     // exploitative fee rate
+    int    daysToRepay = 14;          // typical payday window
+    double riskThreshold = 1.5;       // rollover-risk alert ratio
+
+    double maxRegulatedAPR = 36.0;    // APR cap
+    bool   allowRollover   = false;   // state-level rollover bans
+    bool   requireCoolingOff = true;  // 24h right-to-cancel
+
+    bool showBelmontPrimer      = true;
+    bool showDarkPatternsSource = true;
+    bool showCfpbReference      = true;
+    bool showDelawareCase       = true;
+    bool showSdPilot            = true;
+
+    bool showCostBenefit  = true;
+    bool showDebrief      = true;
+    bool dynamicZip       = true;
+    bool buriedDataNotice = true;
+    bool autoRolloverFinePrint = true;
+    bool showScarcity     = true;
+    bool abCountdown      = true;
+    bool requireQuiz      = true;
+
+    std::string state = "";          // optional state code
+
+    bool forceArbitrationClause = true; // exploitative forced arbitration
+    bool shareDataWithPartners = true;  // exploitative data sale
+    bool banArbitration = true;        // regulated keeps court rights
+
+    bool exportSession       = true;  // persist session JSON
+    bool showAmortization    = true;  // display amortization schedule
+    bool earlyPayoffIncentive = true; // offer early payoff discount
+
+    int  maxLoansPerYear = 5;         // yearly loan limit
+    bool enforceLoanLimit = true;     // enforce loan count cap
+};
+
+#endif

--- a/src/loan_session.cpp
+++ b/src/loan_session.cpp
@@ -1,0 +1,58 @@
+#include "loan_session.h"
+
+void LoanSession::record(const std::string &e, const std::string &d){
+    std::time_t now = std::time(nullptr);
+    history.push_back({e,d,now});
+    if(e=="consent" || e=="metaConsent") {
+        std::ofstream f("consent.log", std::ios::app);
+        if(f.is_open()) f<<now<<","<<e<<","<<d<<"\n";
+    }
+}
+
+int LoanSession::consentScore() const {
+    int score = 100;
+    for(const auto &p: darkPatterns){
+        if(p=="urgency" || p=="fakeConsent" || p=="hiddenAPR") score -= 20;
+        else if(p=="rollover" || p=="guiltTip") score -= 15;
+        else score -= 10;
+    }
+    return std::max(0, score);
+}
+
+void LoanSession::exportJson(const std::string &file) const {
+    std::ofstream o(file);
+    o << "{\n";
+    o << "  \"userName\": \""<<userName<<"\",\n";
+    o << "  \"employer\": \""<<employer<<"\",\n";
+    o << "  \"contact\": \""<<contact<<"\",\n";
+    o << "  \"rushRating\": "<<rushRating<<",\n";
+    o << "  \"amount\": "<<amount<<",\n";
+    o << "  \"fee\": "<<fee<<",\n";
+    o << "  \"tip\": "<<tip<<",\n";
+    o << "  \"freeExtensionUsed\": "<<(freeExtensionUsed?"true":"false")<<",\n";
+    o << "  \"consentScore\": "<<consentScore()<<",\n";
+    o << "  \"manipulationIndex\": "<<manipulationIndex()<<",\n";
+    o << "  \"darkPatterns\": [";
+    for(size_t i=0;i<darkPatterns.size();++i){
+        o << '\"'<<darkPatterns[i]<<'\"';
+        if(i+1<darkPatterns.size()) o << ',';
+    }
+    o << "],\n  \"history\": [";
+    for(size_t i=0;i<history.size();++i){
+        const auto &ev = history[i];
+        o << "{\"type\":\""<<ev.type<<"\",\"data\":\""<<ev.data<<"\",\"ts\": "<<ev.timestamp<<"}";
+        if(i+1<history.size()) o << ',';
+    }
+    o << "]\n}";
+    o.close();
+}
+
+int LoanSession::loadLoanCount(){
+    std::ifstream f("loan_count.txt");
+    int n=0; if(f.is_open()) f>>n; return n;
+}
+
+void LoanSession::saveLoanCount(int n){
+    std::ofstream f("loan_count.txt", std::ios::trunc);
+    if(f.is_open()) f<<n;
+}

--- a/src/loan_session.h
+++ b/src/loan_session.h
@@ -1,0 +1,40 @@
+#ifndef LOTUS_LOAN_SESSION_H
+#define LOTUS_LOAN_SESSION_H
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <ctime>
+#include <fstream>
+#include <algorithm>
+
+struct Event { std::string type, data; std::time_t timestamp; };
+
+class LoanSession {
+public:
+    double amount = 0, fee = 0, tip = 0;
+    std::string userName, employer, contact;
+    int rushRating = 0;
+    bool freeExtensionUsed = false;
+    int loanCount = 0;
+    bool deniedByLimit = false;
+
+    std::vector<Event> history;
+    std::vector<std::string> darkPatterns;
+    std::vector<std::string> recalls;
+    std::vector<std::pair<std::string,std::string>> notices;
+
+    void record(const std::string &e, const std::string &d = "");
+    void tag(const std::string &p) { darkPatterns.push_back(p); }
+    void notice(const std::string &s,const std::string &n){ notices.emplace_back(s,n); }
+    void recall(const std::string &q){ recalls.push_back(q); }
+
+    int consentScore() const;
+    int manipulationIndex() const { return (int)darkPatterns.size(); }
+    void exportJson(const std::string &file) const;
+
+    static int loadLoanCount();
+    static void saveLoanCount(int n);
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,51 @@
+#include "config.h"
+#include "ui.h"
+#include "loan_session.h"
+#include "strategies/ethical.h"
+#include "strategies/exploit.h"
+#include "strategies/regulated.h"
+
+#include <memory>
+#include <cstdlib>
+
+int main(int argc,char* argv[]){
+    srand((unsigned)time(nullptr));
+    Config cfg;
+    UI::show("=== Lotus CLI Simulator ===");
+    std::string mode="";
+    std::string state="";
+    double presetAmt=-1;
+    for(int i=1;i<argc;++i){
+        std::string arg=argv[i];
+        if(arg.rfind("--mode=",0)==0) mode=arg.substr(7);
+        else if(arg.rfind("--loan=",0)==0) presetAmt = std::stod(arg.substr(7));
+        else if(arg.rfind("--state=",0)==0) state=arg.substr(8);
+    }
+    if(mode.empty()) mode = UI::prompt("Select mode (ethical/exploitative/regulated):");
+
+    auto applyState=[&](const std::string& st){
+        if(st=="SD"){ cfg.maxRegulatedAPR=36.0; cfg.showSdPilot=true; cfg.showDelawareCase=false; }
+        else if(st=="DE"){ cfg.maxRegulatedAPR=36.0; cfg.showDelawareCase=true; }
+        else if(st=="RI"){ cfg.maxRegulatedAPR=260.0; cfg.allowRollover=true; }
+        else if(st=="UT"){ cfg.maxRegulatedAPR=400.0; cfg.allowRollover=true; }
+    };
+    if(!state.empty()){ applyState(state); cfg.state = state; }
+
+    std::unique_ptr<LoanStrategy> strat;
+    if(mode=="ethical")       strat = std::make_unique<Ethical>();
+    else if(mode=="regulated") strat = std::make_unique<Regulated>();
+    else                         strat = std::make_unique<Exploit>();
+
+    LoanSession sess;
+    if(presetAmt>0) sess.amount=presetAmt;
+    strat->intro(sess,cfg);
+    strat->consent(sess,cfg);
+    strat->askAmt(sess);
+    strat->calcFee(sess,cfg);
+    strat->extras(sess,cfg);
+    strat->renewals(sess,cfg);
+    strat->finalize(sess,cfg);
+
+    UI::show("Done.");
+    return 0;
+}

--- a/src/strategies/ethical.cpp
+++ b/src/strategies/ethical.cpp
@@ -1,0 +1,86 @@
+#include "ethical.h"
+
+void Ethical::intro(LoanSession &s,const Config &c){
+    if(c.showBelmontPrimer){
+        UI::show("\xF0\x9F\x94\xAC [ETHICAL] Belmont Report Primer (1979):");
+        UI::show(" \u2022 Respect for Persons (Autonomy)");
+        UI::show(" \u2022 Beneficence");
+        UI::show(" \u2022 Non-maleficence");
+        UI::show(" \u2022 Justice");
+        s.record("primer","Belmont Report");
+        UI::show("This ideal scenario prioritizes borrower well-being above profit.");
+        UI::show("Such transparency and low rates would likely require subsidies and face regulatory hurdles,");
+        UI::show("so it is generally impractical in the current payday market.");
+    }
+}
+
+void Ethical::consent(LoanSession &s,const Config &c){
+    if(c.showBelmontPrimer){
+        std::string m;
+        do{
+            m = UI::prompt("Meta-consent: Do you feel any pressure or unfair nudging right now? (yes/no)");
+            s.record("metaConsent",m);
+            if(m=="yes") UI::show("We can pause or review the terms again so your decision remains fully voluntary.");
+        }while(m=="yes");
+    }
+    UI::tooltip("Informed Consent: clear terms, no hidden clauses.");
+    std::string cstr = UI::prompt("Type 'yes' only if you still freely consent:");
+    if(cstr!="yes") { UI::show("Consent withdrawn. Goodbye."); std::exit(0); }
+    s.record("consent",cstr);
+}
+
+double Ethical::askAmt(LoanSession &s){
+    if(s.amount>0){ s.record("amount", std::to_string(s.amount)); return s.amount; }
+    double a = UI::askNum("Enter desired loan amount:");
+    s.amount = a; s.record("amount", std::to_string(a));
+    return a;
+}
+
+double Ethical::calcFee(LoanSession &s,const Config &c){
+    double base = s.amount * (c.apr/100);
+    if(c.showCostBenefit){
+        UI::show("\xF0\x9F\x93\x8B Cost–Benefit Ledger:");
+        UI::show(" \u2022 Funding cost: $" + std::to_string((int)base));
+        UI::show(" \u2022 Admin overhead: $5");
+        UI::show(" → Total fee: $" + std::to_string((int)(base+5)));
+        UI::show("This transparent ledger explains exactly where your money goes to support informed consent and community benefit.");
+    }
+    s.fee = base + 5; s.record("fee", std::to_string(s.fee));
+    return s.fee;
+}
+
+void Ethical::extras(LoanSession &s,const Config &c){
+    UI::show("\nLoan Terms Summary:");
+    UI::show(" • Amount: $" + std::to_string((int)s.amount));
+    UI::show(" • APR: " + std::to_string(c.apr) + "%");
+    UI::show(" • Fee: $" + std::to_string((int)s.fee));
+    UI::show(" • Repay in: " + std::to_string(c.daysToRepay) + " days");
+    UI::show("No post-approval extras: full transparency.");
+}
+
+void Ethical::renewals(LoanSession&, const Config&){
+    UI::show("Rollover ethically discouraged.");
+}
+
+void Ethical::finalize(LoanSession &s,const Config &c){
+    if(c.showDebrief){
+        UI::show("\n\u2500\u2500 Debrief \u2500\u2500");
+        UI::show("\"Act so that you treat humanity never merely as a means...\" — Kant");
+        UI::show("\"The harm principle: only prevent harm to others.\" — Mill");
+        UI::show("\"Justice as fairness.\" — Rawls");
+        UI::show("No hidden fees or pressure were used, respecting your autonomy (Kant). The loan caused no undue harm (Mill) and was offered on fair terms equal to anyone else (Rawls).");
+        UI::show("This utopian approach offers maximal transparency but would rarely sustain a payday business in reality.");
+    }
+    if(c.earlyPayoffIncentive){
+        std::string a = UI::prompt("Early payoff within 7 days for $5 off? (yes/no)");
+        if(a=="yes"){ s.fee = std::max(0.0, s.fee-5); UI::show("Discount applied. New fee: $"+std::to_string((int)s.fee)); }
+    }
+    if(c.showAmortization) UI::schedule(s.amount,s.fee,c.daysToRepay);
+    if(c.exportSession){
+        UI::show("Session will be saved to JSON file.");
+        if(UI::prompt("Proceed? (yes/no)")=="yes") s.exportJson("ethical.json");
+        else UI::show("Export skipped.");
+    }
+    std::string r = UI::prompt("Did this simulation help you understand design influence? (yes/no/comments)");
+    s.record("userReflection", r);
+}

--- a/src/strategies/ethical.h
+++ b/src/strategies/ethical.h
@@ -1,0 +1,17 @@
+#ifndef LOTUS_ETHICAL_H
+#define LOTUS_ETHICAL_H
+
+#include "strategy.h"
+#include "ui.h"
+
+struct Ethical : LoanStrategy {
+    void intro(LoanSession&, const Config&) override;
+    void consent(LoanSession&, const Config&) override;
+    double askAmt(LoanSession&) override;
+    double calcFee(LoanSession&, const Config&) override;
+    void extras(LoanSession&, const Config&) override;
+    void renewals(LoanSession&, const Config&) override;
+    void finalize(LoanSession&, const Config&) override;
+};
+
+#endif

--- a/src/strategies/exploit.cpp
+++ b/src/strategies/exploit.cpp
@@ -1,0 +1,110 @@
+#include "../summary.h"
+#include "exploit.h"
+#include <cstdlib>
+
+std::string getFakeZip(){
+    std::string z; for(int i=0;i<5;++i) z += char('0'+rand()%10); return z;
+}
+
+void Exploit::intro(LoanSession &s,const Config &c){
+    if(c.showDarkPatternsSource)
+        UI::legalNotice("Source: KTH Dark Patterns in BNPL Services (2020)");
+    if(c.dynamicZip){
+        std::string zip=getFakeZip();
+        UI::show("🎯 Special rate for " + zip + " residents today!");
+        s.record("zipPersonalization",zip);
+    }
+    UI::show("\"PaydayPlus saved me when no one else would!\" - Satisfied Customer");
+    UI::show("These aggressive marketing tactics mirror real payday websites that emphasize quick cash while hiding the true cost.");
+    if(c.buriedDataNotice && c.shareDataWithPartners){
+        UI::tiny("By proceeding you allow sale of data to credit_broker_xyz.com");
+        s.record("dataNotice","soldTo=credit_broker_xyz.com");
+    }
+}
+
+void Exploit::consent(LoanSession &s,const Config& c){
+    if(c.forceArbitrationClause){
+        UI::show("By proceeding, you agree to resolve all disputes via binding arbitration.");
+        while(UI::prompt("Type 'I AGREE' to continue:")!="I AGREE"){}
+    }
+    else {
+        UI::show("Standard terms apply.");
+    }
+    s.tag("fakeConsent");
+}
+
+double Exploit::askAmt(LoanSession &s){
+    if(rand()%2){ UI::show("🔥 Only 2 spots left!"); UI::wait(5);} else { UI::show("🔥 Only 2 spots left!"); UI::wait(10);}    
+    s.tag("urgency");
+    if(s.amount>0){ s.record("amount",std::to_string(s.amount)); return s.amount; }
+    double a = UI::askNum("How much do you need today? $");
+    s.amount=a; s.record("amount",std::to_string(a));
+    return a;
+}
+
+double Exploit::calcFee(LoanSession &s,const Config &c){
+    double f = s.amount*c.exploitFeeRate;
+    double svc = s.amount*0.05; // hidden processing fee
+    double orig = s.amount*0.10; // origination fee
+    double total = f+svc+orig;
+    UI::show("Service charge: $" + std::to_string((int)(svc+orig)));
+    s.tag("hiddenAPR");
+    s.record("fee", std::to_string(total));
+    return s.fee=total;
+}
+
+void Exploit::extras(LoanSession &s,const Config&){
+    UI::show("Approved! 🎉"); UI::bank();
+    UI::show("💬 78% of users tip 15% — help us too!");
+    std::string in = UI::prompt("Support us? (tip %) [15]: ");
+    double pct = in.empty()?15.0:std::stod(in);
+    if(pct<=0){ s.tag("forcedTip"); pct=15.0; }
+    if(pct>0) s.tag("guiltTip");
+    double t = s.amount*(pct/100.0);
+    s.tip=t; s.record("tip",std::to_string(t));
+}
+
+void Exploit::renewals(LoanSession &s,const Config &c){
+    if(c.autoRolloverFinePrint){
+        std::string a = UI::prompt("Need more time? Type 'YES' to extend");
+        while(a=="YES"){
+            s.tag("autoRollover");
+            s.record("autoRoll","14d");
+            s.fee += s.amount*0.15;
+            UI::show("➕ Auto-rollover fee applied");
+            a = UI::prompt("Need more time? Type 'YES' to extend");
+        }
+    }
+}
+
+void Exploit::finalize(LoanSession &s,const Config &c){
+    double total=s.amount+s.fee+s.tip;
+    if((total/s.amount)>c.riskThreshold)
+        UI::show("⚠️ High rollover risk ratio="+std::to_string(total/s.amount));
+    s.userName = UI::prompt("Your name:");
+    s.employer = UI::prompt("Your employer:");
+    UI::show("Processing direct debit authorization...");
+    s.record("wageAssignment", s.employer);
+    s.contact = UI::prompt("Contact info:");
+    s.rushRating = std::stoi(UI::prompt("Rate how rushed you felt (1-5):"));
+    std::string pay = UI::prompt("Will funds be available on payday? (yes/no)");
+    if(pay=="no"){
+        UI::show("Attempting automatic debit...");
+        for(int i=0;i<3;++i){
+            UI::show("Debit attempt " + std::to_string(i+1) + " failed. NSF fee $35.");
+        }
+        s.tag("overdraftFees");
+    }
+    printSummary(s); generateFollowUpEmail(s);
+    UI::show("⚠️ Missed payment reported to credit bureaus. Credit score impacted.");
+    if(c.showAmortization) UI::schedule(s.amount,s.fee,c.daysToRepay);
+    UI::show("Expect promotional offers from our partners soon!");
+    UI::show("This sequence mirrors practices reported on actual payday loan sites, including persistent collection attempts and credit threats.");
+    if(c.exportSession){
+        UI::show("Session will be saved to JSON file.");
+        if(UI::prompt("Proceed? (yes/no)")=="yes") s.exportJson("exploit.json");
+        else UI::show("Export skipped.");
+    }
+    std::string r = UI::prompt("Did this simulation help you understand design influence? (yes/no/comments)");
+    s.record("userReflection", r);
+}

--- a/src/strategies/exploit.h
+++ b/src/strategies/exploit.h
@@ -1,0 +1,20 @@
+#ifndef LOTUS_EXPLOIT_H
+#define LOTUS_EXPLOIT_H
+
+#include "strategy.h"
+#include "ui.h"
+#include "config.h"
+
+std::string getFakeZip();
+
+struct Exploit : LoanStrategy {
+    void intro(LoanSession&, const Config&) override;
+    void consent(LoanSession&, const Config&) override;
+    double askAmt(LoanSession&) override;
+    double calcFee(LoanSession&, const Config&) override;
+    void extras(LoanSession&, const Config&) override;
+    void renewals(LoanSession&, const Config&) override;
+    void finalize(LoanSession&, const Config&) override;
+};
+
+#endif

--- a/src/strategies/regulated.cpp
+++ b/src/strategies/regulated.cpp
@@ -1,0 +1,104 @@
+#include "../summary.h"
+#include "regulated.h"
+
+void Regulated::intro(LoanSession& s, const Config& c){
+    UI::show("🏛 Regulated mode: CFPB & State Constraints");
+    if(!c.state.empty()) UI::show("Applying rules for state: " + c.state);
+    UI::show("This scenario reflects real payday regulations and remains commercially viable while offering key consumer protections.");
+    if(c.enforceLoanLimit){
+        int count = LoanSession::loadLoanCount();
+        s.loanCount = count;
+        if(count >= c.maxLoansPerYear){
+            UI::show("⚠️ Limit Reached: State law limits you to " + std::to_string(c.maxLoansPerYear) + " loans per year.");
+            s.deniedByLimit = true;
+        }
+    }
+}
+
+void Regulated::consent(LoanSession &s,const Config &c){
+    if(s.deniedByLimit){ return; }
+    if(c.requireQuiz){
+        std::string a;
+        do{ a=UI::prompt("Quiz: Which number is the APR? (enter percentage)"); }
+        while(std::stod(a)!=c.maxRegulatedAPR);
+        s.record("quizPassed",a);
+    }
+    if(c.banArbitration) UI::show("✅ You retain your right to sue in court — no arbitration required.");
+    if(c.shareDataWithPartners){
+        if(UI::prompt("Share data with partners? (yes/no)") != "yes")
+            UI::show("🔒 Data will not be shared.");
+    }
+    UI::show("Amount Financed and APR will be disclosed clearly below.");
+    while(UI::prompt("Type 'I AGREE' to accept plain-language TILA statement:") != "I AGREE"){}
+    s.record("consent","I AGREE");
+}
+
+double Regulated::askAmt(LoanSession &s){
+    if(s.deniedByLimit) return 0.0;
+    UI::show("🔌 Reading your bank balance...");
+    UI::show("Detected balance: $750");
+    if(s.amount>0){ s.record("amount", std::to_string(s.amount)); return s.amount; }
+    double a = UI::askNum("Enter loan amount (<=50% balance): $");
+    s.amount=a; s.record("amount",std::to_string(a));
+    return a;
+}
+
+double Regulated::calcFee(LoanSession &s,const Config &c){
+    if(s.deniedByLimit) return 0.0;
+    double apr = std::min(c.apr,c.maxRegulatedAPR);
+    double f   = s.amount*(apr/100);
+    s.record("fee", std::to_string(f));
+    if(c.showCfpbReference) UI::legalNotice("CFPB Reg Z §1026: 36% APR cap");
+    if(c.showDelawareCase)  UI::legalNotice("Delaware v. X Corp (2024): usury cap enforced");
+    if(c.showSdPilot)       UI::legalNotice("SD Pilot: 0% APR extension once/year");
+    if(c.requireCoolingOff) UI::show("Cooling-off: You may cancel within 24h.");
+    return s.fee=f;
+}
+
+void Regulated::extras(LoanSession&, const Config&){ }
+
+void Regulated::renewals(LoanSession &s,const Config &c){
+    if(s.deniedByLimit) return;
+    if(!c.allowRollover) UI::show("🚫 Auto-rollover prohibited by law.");
+    if(c.showSdPilot && !s.freeExtensionUsed){
+        std::string r = UI::prompt("ℹ️ One-time 0% extension available. Type 'YES' to use it:");
+        if(r=="YES"){
+            s.freeExtensionUsed=true;
+            s.record("freeExtension","granted");
+            UI::show("Extension granted at 0% APR for 30 days.");
+        }
+    }
+}
+
+void Regulated::finalize(LoanSession &s,const Config &c){
+    if(s.deniedByLimit){ return; }
+    s.userName = UI::prompt("Your name:");
+    s.employer = UI::prompt("Employer:");
+    s.contact  = UI::prompt("Contact:");
+    UI::show("\n==== Truth in Lending Disclosure ====");
+    UI::show("Amount Financed: $" + std::to_string((int)s.amount));
+    UI::show("Finance Charge: $" + std::to_string((int)s.fee));
+    double apr = std::min(c.apr,c.maxRegulatedAPR);
+    UI::show("APR: " + std::to_string(apr) + "%");
+    UI::show("Total of Payments: $" + std::to_string((int)(s.amount+s.fee)));
+    UI::show("Payment Due in " + std::to_string(c.daysToRepay) + " days");
+    while(UI::prompt("Type 'I AGREE' to confirm these terms:")!="I AGREE"){}
+    printSummary(s);
+    UI::show("Compliance Report:");
+    UI::show(" • APR cap applied: " + std::string(c.apr>c.maxRegulatedAPR?"YES":"NO"));
+    UI::show(" • Cooling-off right: " + std::string(c.requireCoolingOff?"YES":"NO"));
+    UI::show(" • Rollovers allowed: " + std::string(c.allowRollover?"YES":"NO"));
+    UI::show("These safeguards reflect real laws while keeping the loan profitable enough that lenders remain in the market.");
+    if(c.showAmortization) UI::schedule(s.amount,s.fee,c.daysToRepay);
+    if(c.exportSession){
+        UI::show("Session will be saved to JSON file.");
+        if(UI::prompt("Proceed? (yes/no)")=="yes") s.exportJson("regulated.json");
+        else UI::show("Export skipped.");
+    }
+    std::string resp = UI::prompt("Type 'cancel' within 24h to rescind this loan:");
+    if(resp=="cancel"){ UI::show("✅ Loan cancelled under rescission rule."); return; }
+    int count = LoanSession::loadLoanCount();
+    if(c.enforceLoanLimit) LoanSession::saveLoanCount(count+1);
+    std::string r = UI::prompt("Did this simulation help you understand design influence? (yes/no/comments)");
+    s.record("userReflection", r);
+}

--- a/src/strategies/regulated.h
+++ b/src/strategies/regulated.h
@@ -1,0 +1,17 @@
+#ifndef LOTUS_REGULATED_H
+#define LOTUS_REGULATED_H
+
+#include "strategy.h"
+#include "ui.h"
+
+struct Regulated : LoanStrategy {
+    void intro(LoanSession&, const Config&) override;
+    void consent(LoanSession&, const Config&) override;
+    double askAmt(LoanSession&) override;
+    double calcFee(LoanSession&, const Config&) override;
+    void extras(LoanSession&, const Config&) override;
+    void renewals(LoanSession&, const Config&) override;
+    void finalize(LoanSession&, const Config&) override;
+};
+
+#endif

--- a/src/strategies/strategy.h
+++ b/src/strategies/strategy.h
@@ -1,0 +1,18 @@
+#ifndef LOTUS_STRATEGY_H
+#define LOTUS_STRATEGY_H
+
+#include "loan_session.h"
+#include "config.h"
+
+struct LoanStrategy {
+    virtual void intro(LoanSession&, const Config&) =0;
+    virtual void consent(LoanSession&, const Config&) =0;
+    virtual double askAmt(LoanSession&) =0;
+    virtual double calcFee(LoanSession&, const Config&) =0;
+    virtual void extras(LoanSession&, const Config&) =0;
+    virtual void renewals(LoanSession&, const Config&) =0;
+    virtual void finalize(LoanSession&, const Config&) =0;
+    virtual ~LoanStrategy(){}
+};
+
+#endif

--- a/src/summary.h
+++ b/src/summary.h
@@ -1,0 +1,20 @@
+#ifndef LOTUS_SUMMARY_H
+#define LOTUS_SUMMARY_H
+
+#include "loan_session.h"
+#include "ui.h"
+
+inline void printSummary(const LoanSession &s){
+    UI::show("\n\u2500\u2500 SESSION SUMMARY \u2500\u2500");
+    UI::show("Consent Integrity: " + std::to_string(s.consentScore()) + "/100");
+    UI::show("Manipulation Index: " + std::to_string(s.manipulationIndex()));
+}
+
+inline void generateFollowUpEmail(const LoanSession &s){
+    UI::show("\n📧 Follow-Up Email Preview:");
+    UI::show("Dear " + s.userName + ",");
+    UI::show("Thank you for using Lotus Simulator. Feel free to revisit terms or extend responsibly.");
+    UI::show("Sincerely, Lotus Team");
+}
+
+#endif

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,0 +1,46 @@
+#ifndef LOTUS_UI_H
+#define LOTUS_UI_H
+
+#include <iostream>
+#include <string>
+#include <thread>
+#include <chrono>
+
+namespace UI {
+    inline void show(const std::string &s){ std::cout<<s<<"\n"; }
+    inline std::string prompt(const std::string &s){
+        show(s); std::string r; std::getline(std::cin,r);
+        if(r=="exit") { show("Session ended by user."); std::exit(0); }
+        return r;
+    }
+    inline double askNum(const std::string &s){
+        while(true){
+            std::string v = prompt(s);
+            try { double x = std::stod(v); if(x>0) return x; }
+            catch(...){}
+            show("\u26A0\uFE0F Enter a valid number or type 'exit' to quit.");
+        }
+    }
+    inline void wait(int s){
+        for(;s>0;--s){
+            show("\u23F1 " + std::to_string(s) + "s");
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
+    inline void bank(){
+        show("🔒 Connecting bank...");
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        show("✅ Bank connected securely.");
+    }
+    inline void tiny(const std::string &t){ std::cout<<"(tiny) "<<t<<"\n"; }
+    inline void tooltip(const std::string &t){ show("🛈 " + t); }
+    inline void legalNotice(const std::string &t){ show("⚖️ " + t); }
+    inline void schedule(double amt,double fee,int days){
+        double total=amt+fee;
+        double daily=total/days;
+        show("Amortization Schedule:");
+        for(int d=1; d<=days; ++d) show(" Day " + std::to_string(d) + ": $" + std::to_string(daily*d));
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- introduce `--state=` flag and Config::state
- adjust regulated APR caps for SD, DE, RI, and UT
- print state rules during regulated intro
- clarify ethical mode limitations in messages and README

## Testing
- `g++ -std=c++17 -I src -o lotus src/main.cpp src/loan_session.cpp src/strategies/*.cpp && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_6858baeaee18832c95aacf045b4da74a